### PR TITLE
AS option for Validator

### DIFF
--- a/Ucc/Data/Validator/Validator.php
+++ b/Ucc/Data/Validator/Validator.php
@@ -327,8 +327,11 @@ class Validator implements ValidatorInterface
             try {
                 // Call method to validate data
                 $result = call_user_func_array($callable, $args);
-                $this->addSafeData($key, $result);
-
+                if (isset($requirements['as'])) {
+                    $this->addSafeData($requirements['as'], $result);
+                } else {
+                    $this->addSafeData($key, $result);
+                }
                 return $this;
             } catch (\Exception $e) {
                 $this->setError('Field ' . $key . ' failed validation because ' . $e->getMessage());


### PR DESCRIPTION
So passing `as` into validator will return data as given value, for example:

```php
$checks = array(
            'developmentId'  => array(
                'type'      => 'custom',
                'class'     => $this->get('pdms.validator.development'),
                'method'    => 'checkIsValidDevelopment',
                'opt'       => true,
                'as'        => 'development',
            ),
);
```

In this case `developmentId` will be return as `development` in safeData